### PR TITLE
feat: Add common usage patterns section to module docs

### DIFF
--- a/llmap/llm.py
+++ b/llmap/llm.py
@@ -19,7 +19,7 @@ You are generating documentation for a code module to help other LLMs understand
 
 Generate a markdown document following this template:
 
-```markdown
+````markdown
 # Module: {module_name}
 
 **Purpose**: [One sentence describing what this module does]
@@ -69,7 +69,7 @@ Extract examples from test files or examples in the codebase when available.
 
 - `filename.cpp` – Brief purpose
 - [List all files with one-line descriptions]
-```
+````
 
 Focus on:
 - The module's PURPOSE (what problem it solves)

--- a/llmap/llm.py
+++ b/llmap/llm.py
@@ -44,6 +44,23 @@ Generate a markdown document following this template:
 - `function_signature` – What it does
 - [List main public APIs]
 
+## Common Usage Patterns
+
+Provide 1-2 practical code examples showing how to use this module:
+
+### [Pattern Name, e.g., "Basic Usage" or "Initialization"]
+```[language]
+// Example code showing typical usage
+```
+
+### [Pattern Name, e.g., "Error Handling" or "Advanced Usage"]
+```[language]
+// Example code showing error handling or advanced patterns
+```
+
+Focus on: initialization, main workflow, and error handling patterns.
+Extract examples from test files or examples in the codebase when available.
+
 ## Invariants & Design Notes
 
 - [Important rules, assumptions, or design decisions]
@@ -58,6 +75,7 @@ Focus on:
 - The module's PURPOSE (what problem it solves)
 - Its DEPENDENCIES (what it needs, what needs it)
 - KEY COMPONENTS (most important functions/classes)
+- USAGE PATTERNS (practical examples for integration)
 - INVARIANTS (important rules/assumptions)
 
 Be concise. Avoid restating obvious code. Focus on architectural understanding.


### PR DESCRIPTION
Fixes #4

## Changes
- Updated `MODULE_PROMPT` in `llm.py` to include a **Common Usage Patterns** section
- Instructs the LLM to generate 1-2 practical code examples per module
- Focus on initialization, main workflow, and error handling patterns
- Encourages extraction from tests or example files when available

## Benefit
LLMs consuming the generated codemap can generate correct code that integrates with modules on the first try.