### PR TITLE
feat: Add Related Modules section with bidirectional navigation links

### DIFF
--- a/llmap/modules.py
+++ b/llmap/modules.py
@@ -12,6 +12,8 @@ class Module:
     name: str
     path: Path
     files: list[tuple[Path, str]] = field(default_factory=list)  # (path, hash)
+    dependencies: set[str] = field(default_factory=set)  # Module names this depends on
+    dependents: set[str] = field(default_factory=set)  # Module names that depend on this
     
     def add_file(self, path: Path, file_hash: str):
         self.files.append((path, file_hash))
@@ -82,3 +84,75 @@ class ModuleGrouper:
             modules[module_name].add_file(path, file_hash)
         
         return list(modules.values())
+
+
+class DependencyResolver:
+    """Resolves dependencies between modules based on import analysis."""
+    
+    def __init__(self, modules: list[Module]):
+        self.modules = modules
+        self.root = Path.cwd()
+        # Map from file path (relative) to module name
+        self._file_to_module: dict[str, str] = {}
+        for module in modules:
+            for path, _ in module.files:
+                rel_path = str(path.relative_to(self.root))
+                self._file_to_module[rel_path] = module.name
+                # Also map by filename for simple includes
+                self._file_to_module[path.name] = module.name
+    
+    def resolve_import(self, importing_file: Path, import_name: str) -> str | None:
+        """Resolve an import to a module name.
+        
+        Args:
+            importing_file: The file containing the import
+            import_name: The import path (e.g., "../lexer/token.h" or "semantic.h")
+            
+        Returns:
+            Module name if resolved, None otherwise
+        """
+        # Try direct filename match first
+        if import_name in self._file_to_module:
+            return self._file_to_module[import_name]
+        
+        # Try resolving relative path from importing file's directory
+        try:
+            import_path = (importing_file.parent / import_name).resolve()
+            rel_path = str(import_path.relative_to(self.root))
+            if rel_path in self._file_to_module:
+                return self._file_to_module[rel_path]
+        except (ValueError, OSError):
+            pass
+        
+        return None
+    
+    def build_dependency_graph(
+        self,
+        module_structures: dict[str, list["FileStructure"]]
+    ) -> None:
+        """Build bidirectional dependency graph for all modules.
+        
+        Args:
+            module_structures: Map from module name to list of parsed FileStructures
+        """
+        from .parser import FileStructure  # Import here to avoid circular import
+        
+        module_by_name = {m.name: m for m in self.modules}
+        
+        for module in self.modules:
+            structures = module_structures.get(module.name, [])
+            
+            for structure in structures:
+                for imp in structure.imports:
+                    # Skip system imports
+                    if imp.is_system:
+                        continue
+                    
+                    target_module = self.resolve_import(structure.path, imp.name)
+                    if target_module and target_module != module.name:
+                        # Add dependency: this module depends on target
+                        module.dependencies.add(target_module)
+                        # Add reverse: target is depended on by this module
+                        if target_module in module_by_name:
+                            module_by_name[target_module].dependents.add(module.name)
+


### PR DESCRIPTION
## Summary

Adds a "Related Modules" section to each generated module document with relative links to related modules, enabling LLMs to navigate the codebase graph without returning to overview.md for every hop.

## Changes

- **llmap/modules.py**: Added `dependencies` and `dependents` fields to `Module` dataclass, and new `DependencyResolver` class that analyzes imports to build bidirectional dependency graph
- **llmap/generator.py**: Added `add_related_modules_section()` method that appends navigable relative links to module docs
- **llmap/cli.py**: Updated `update` command to collect parsed structures, run dependency resolution, and add Related Modules sections

## Example Output

Each module file will now include:

```markdown
---

## Related Modules

**Depends on**:
- [lexer](./lexer.md)
- [utils](./utils.md)

**Depended by**:
- [semantic](./semantic.md)
```

Fixes #1